### PR TITLE
Fix typo in postscript

### DIFF
--- a/src/Postscript.js
+++ b/src/Postscript.js
@@ -12,7 +12,7 @@ class Postscript extends React.Component {
   render() {
     return <Box pad="large" className="postcript">
       <Configure size="large" color="#999" />
-      <Paragraph size="small">Created by <Anchor href="https://chriszetter.com">Chris Zetter</Anchor> in a tribute to Rails and <Anchor href="https://contributors.rubyonrails.org/contributors">it's many contributors.</Anchor></Paragraph>
+      <Paragraph size="small">Created by <Anchor href="https://chriszetter.com">Chris Zetter</Anchor> in a tribute to Rails and <Anchor href="https://contributors.rubyonrails.org/contributors">its many contributors.</Anchor></Paragraph>
       <Paragraph size="small">You can <Anchor href="http://github.com/zetter/rails-trace">see the code that powers this page</Anchor> and <Anchor href="https://github.com/zetter/rails-trace/issues/new">suggest resources to link to</Anchor> on GitHub.</Paragraph>
     </Box>
   }


### PR DESCRIPTION
Fix typo from `it's` to `its`.

Very cool resource, learned a lot. Thanks for building this! 👏 